### PR TITLE
Autoloads file for MELPA packaging/compatibility

### DIFF
--- a/themes/sublime-themes-autoloads.el
+++ b/themes/sublime-themes-autoloads.el
@@ -1,0 +1,9 @@
+;;; sublime-themes-autoloads.el --- A collection of themes based on Sublime Text
+;;
+;;; Code:
+
+(when (boundp 'custom-theme-load-path)
+  (add-to-list 'custom-theme-load-path (file-name-as-directory
+                                        (file-name-directory load-file-name))))
+
+;;; sublime-themes-autoloads.el ends here


### PR DESCRIPTION
By adding `sublime-themes-autoloads.el` this directory can now be packaged
automatically by MELPA and can be packaged for Marmalade. While it serves the
same purpose of the ;;;###autoload statements,
`package.el` doesn't currently support parsing files that don't match the
name of the package. Thus, every theme would need to be package individually.
However, I think to reduce the amount of noise (there are a lot of packages
available) it's best to just package all these themes as a single installable
package.
