### PR TITLE
Introduce sublime-themes.el instead of autoloads file

### DIFF
--- a/themes/sublime-themes-autoloads.el
+++ b/themes/sublime-themes-autoloads.el
@@ -1,9 +1,0 @@
-;;; sublime-themes-autoloads.el --- A collection of themes based on Sublime Text
-;;
-;;; Code:
-
-(when (boundp 'custom-theme-load-path)
-  (add-to-list 'custom-theme-load-path (file-name-as-directory
-                                        (file-name-directory load-file-name))))
-
-;;; sublime-themes-autoloads.el ends here

--- a/themes/sublime-themes.el
+++ b/themes/sublime-themes.el
@@ -1,0 +1,34 @@
+;;; sublime-themes.el --- A collection of themes based on Sublime Text
+
+;; Copyright (C) 2013 Owain Lewis
+
+;; Author: Owain Lewis <owain@owainlewis.com>
+;; Keywords: faces
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
+
+;;;###autoload
+(when (boundp 'custom-theme-load-path)
+  (add-to-list 'custom-theme-load-path (file-name-as-directory
+                                        (file-name-directory load-file-name))))
+
+
+
+(provide 'sublime-themes)
+;;; sublime-themes.el ends here


### PR DESCRIPTION
@milkypostman's contribution of the autoloads file is only part of the story for MELPA: we also need to grab the package description from somewhere, and that place should usually be a .el file corresponding to the package name.

This commit, then, introduces a `sublime-themes.el` file with a description and author info, and it contains an autoloaded block which
will be used to _generate_ sublime-theme-autoloads.el at package installation time.
