### PR TITLE
Made a change in the color to the junio-comment-slate

### DIFF
--- a/themes/junio-theme.el
+++ b/themes/junio-theme.el
@@ -24,7 +24,7 @@
 
 (let ((junio-background     "#111010")
       (junio-foreground     "#D8D8D3")
-      (junio-comment-slate  "#4F3F3F")
+      (junio-comment-slate  "#76AB55")
       (junio-black          "#000000")
       (junio-constant       "#6F8FCC")
       (junio-mid-gray       "#555555")


### PR DESCRIPTION
I've been using this theme for almost 6 months now and I love it! But one thing that has always bugged me was the default color for the comments. It's only slightly lighter brown than the background and I often have to lean in very very close to the monitor to read the comments. :)

I've changed the color to what I think is a sligtly better one. I realize that color preferences are a highly personal thing and that you may feel that this is the wrong color or that it doesn't fit with the theme. That's completely fine! :) I'm just submitting this because I feel that it might help others using this theme.

Thanks for maintaining these awesome themes! :D

Here's a screenshot of the theme with the new color. http://i.imgur.com/1lC4KEW.png
