### PR TITLE
Fixes ordering of emacs version check variable

### DIFF
--- a/themes/brin-theme.el
+++ b/themes/brin-theme.el
@@ -17,7 +17,7 @@
 ;;
 ;; *****************************************************************************************
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme brin "Space Grey theme for Emacs")

--- a/themes/dorsey-theme.el
+++ b/themes/dorsey-theme.el
@@ -17,7 +17,7 @@
 ;;
 ;; ----------------------------
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme dorsey

--- a/themes/fogus-theme.el
+++ b/themes/fogus-theme.el
@@ -17,7 +17,7 @@
 ;;
 ;; ----------------------------
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme fogus

--- a/themes/graham-theme.el
+++ b/themes/graham-theme.el
@@ -17,7 +17,7 @@
 ;;
 ;; ----------------------------
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme graham "A dark color theme for Emacs")

--- a/themes/granger-theme.el
+++ b/themes/granger-theme.el
@@ -17,7 +17,7 @@
 ;;
 ;; *****************************************************************************************
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme granger "Light table theme for Emacs")

--- a/themes/hickey-theme.el
+++ b/themes/hickey-theme.el
@@ -17,7 +17,7 @@
 ;;
 ;; ----------------------------
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme hickey "A dark colour theme")

--- a/themes/junio-theme.el
+++ b/themes/junio-theme.el
@@ -17,7 +17,7 @@
 ;; 
 ;; ----------------------------
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme junio "A vivid theme like chocolates")

--- a/themes/mccarthy-theme.el
+++ b/themes/mccarthy-theme.el
@@ -17,7 +17,7 @@
 ;;
 ;; ----------------------------
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme mccarthy "A dark color theme for Emacs")

--- a/themes/odersky-theme.el
+++ b/themes/odersky-theme.el
@@ -17,7 +17,7 @@
 ;;
 ;; ----------------------------
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme odersky "A dark color theme for Emacs")

--- a/themes/ritchie-theme.el
+++ b/themes/ritchie-theme.el
@@ -20,7 +20,7 @@
 
 ;;; Code:
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme ritchie "Uncertain amount of shades of blue.")

--- a/themes/spolsky-theme.el
+++ b/themes/spolsky-theme.el
@@ -17,7 +17,7 @@
 ;;
 ;; ----------------------------
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme spolsky  "A dark color theme for Emacs based on Sublime Text 2")

--- a/themes/wilson-theme.el
+++ b/themes/wilson-theme.el
@@ -17,7 +17,7 @@
 ;;
 ;; -------------------------------------------------------
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "requires Emacs 24 or later."))
 
 (deftheme wilson


### PR DESCRIPTION
Running emacs 25.0.50 breaks the themes, which discovered this bug. The function params are reversed.
