### PR TITLE
Fix escaped newlines in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-TARGET="~/.emacs.d/themes"
+TARGET=~/.emacs.d/themes
 
 echo -e "\nInstalling themes [$TARGET]..."
 mkdir -p $TARGET


### PR DESCRIPTION
The install.sh script echoes literal '\n' instead of newlines; I changed the relevant lines to 'echo -e' to interpret escaped characters.  Additionally, I added a `TARGET=~/.emacs.d/themes` variable to simplify the script.
