### PR TITLE
Add company-mode colours that match Spolsky to replace the default company colours.

### DIFF
--- a/themes/spolsky-theme.el
+++ b/themes/spolsky-theme.el
@@ -23,8 +23,8 @@
 (deftheme spolsky  "A dark color theme for Emacs based on Sublime Text 2")
 
 (custom-theme-set-variables
-  'spolsky
-  '(linum-format " %7i "))
+ 'spolsky
+ '(linum-format " %7i "))
 
 (let ((*background*         "#161A1F")
       (*comments*           "#8C8C8C")
@@ -51,6 +51,12 @@
       (*string*             "#EEDC82")
       (*variable*           "#FD971F")
       (*visual-selection*   "#555"))
+
+  ;;(defvar spolsky-colours
+  ;;'((background-light   "#303439")
+  ;;(background-lighter "#494D52")
+  ;;(background-darker  "#000106")
+  ;;))
 
   (custom-theme-set-faces
    'spolsky
@@ -105,6 +111,22 @@
    `(isearch-fail ((t (:background, *warning*))))
    `(lazy-highlight ((t (:background, *operators* :foreground, *visual-selection*))))
 
+   ;; company-mode
+   `(company-tooltip ((t (:foreground, *normal* :background, *current-line*))))
+   `(company-tooltip-annotation ((t (:foreground, *variable* :background, *current-line*))))
+   `(company-tooltip-annotation-selection ((t (:foreground, *method-declaration* :background, *background*))))
+   `(company-tooltip-selection ((t (:foreground, *normal* :background, *background*))))
+   `(company-tooltip-mouse ((t (:background, *background*))))
+   `(company-tooltip-common ((t (:foreground, *type-face*))))
+   `(company-tooltip-common-selection ((t (:foreground, *type-face*))))
+   `(company-scrollbar-fg ((t (:background, *background*))))
+   `(company-scrollbar-bg ((t (:background, *background*))))
+   `(company-preview ((t (:background, *type-face*))))
+   `(company-preview-common ((t (:foreground, *type-face* :background, *background*))))
+
+   ;; company-quickhelp
+   `(company-quickhelp-color-background, *current-line*)
+   `(company-quickhelp-color-foreground, *current-line*)
    ))
 
 ;;;###autoload
@@ -117,5 +139,3 @@
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; End:
-
-


### PR DESCRIPTION
1. Why is this change neccesary?
Company mode (used for auto-complete) had the default colours for company-mode, those colours don't match Spolsky's colours.

Other themes like Zenburn or Spacemacs (light and dark variants) had specific colours for company-mode so the popup window matches the theme.

2. How does it address the issue?
The colours for company-mode where added.

3. What side effects does this change have?
The colours now match Spolsky!

**Before:**
![screenshot_2018-12-08_01-09-09](https://user-images.githubusercontent.com/10160626/49683189-0ae2d680-fa86-11e8-8baf-dda9fb7faf66.png)


**After:**
![screenshot_2018-12-08_01-10-12](https://user-images.githubusercontent.com/10160626/49683191-10402100-fa86-11e8-9bf6-de8b6870e338.png)